### PR TITLE
Work around some type issues

### DIFF
--- a/examples/readme_errors.rs
+++ b/examples/readme_errors.rs
@@ -15,6 +15,7 @@ extern crate serde_derive;
 use std::error::Error;
 use std::fmt;
 use tarpc::sync::Connect;
+use tarpc::{ClientConfig, ServerConfig};
 
 service! {
     rpc hello(name: String) -> String | NoNameGiven;
@@ -39,7 +40,7 @@ impl Error for NoNameGiven {
 struct HelloServer;
 
 impl SyncService for HelloServer {
-    fn hello(&mut self, name: String) -> Result<String, NoNameGiven> {
+    fn hello(&self, name: String) -> Result<String, NoNameGiven> {
         if name == "" {
             Err(NoNameGiven)
         } else {
@@ -49,8 +50,8 @@ impl SyncService for HelloServer {
 }
 
 fn main() {
-    let addr = HelloServer.listen("localhost:10000").unwrap();
-    let client = SyncClient::connect(addr).unwrap();
+    let addr = HelloServer.listen("localhost:10000", ServerConfig::new_tcp()).unwrap();
+    let client = SyncClient::connect(addr, ClientConfig::new_tcp()).unwrap();
     println!("{}", client.hello("Mom".to_string()).unwrap());
     println!("{}", client.hello("".to_string()).unwrap_err());
 }

--- a/examples/readme_sync.rs
+++ b/examples/readme_sync.rs
@@ -22,14 +22,14 @@ service! {
 struct HelloServer;
 
 impl SyncService for HelloServer {
-    fn hello(&mut self, name: String) -> Result<String, Never> {
+    fn hello(&self, name: String) -> Result<String, Never> {
         Ok(format!("Hello, {}!", name))
     }
 }
 
 fn main() {
     let addr = "localhost:10000";
-    HelloServer.listen(addr).unwrap();
-    let mut client = SyncClient::connect(addr).unwrap();
+    HelloServer.listen(addr, tarpc::ServerConfig::new_tcp()).unwrap();
+    let client = SyncClient::connect(addr, tarpc::ClientConfig::new_tcp()).unwrap();
     println!("{}", client.hello("Mom".to_string()).unwrap());
 }

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -21,6 +21,7 @@ use std::io::{Read, Write, stdout};
 use futures::Future;
 use tarpc::sync::Connect;
 use tarpc::util::{FirstSocketAddr, Never};
+use tarpc::{ClientConfig, ServerConfig};
 
 lazy_static! {
     static ref BUF: Arc<Vec<u8>> = Arc::new(gen_vec(CHUNK_SIZE as usize));
@@ -44,7 +45,7 @@ struct Server;
 impl FutureService for Server {
     type ReadFut = futures::Finished<Arc<Vec<u8>>, Never>;
 
-    fn read(&mut self) -> Self::ReadFut {
+    fn read(&self) -> Self::ReadFut {
         futures::finished(BUF.clone())
     }
 }
@@ -52,8 +53,8 @@ impl FutureService for Server {
 const CHUNK_SIZE: u32 = 1 << 19;
 
 fn bench_tarpc(target: u64) {
-    let addr = Server.listen("localhost:0".first_socket_addr()).wait().unwrap();
-    let client = SyncClient::connect(&addr).unwrap();
+    let addr = Server.listen("localhost:0".first_socket_addr(), ServerConfig::new_tcp()).wait().unwrap();
+    let client = SyncClient::connect(&addr, ClientConfig::new_tcp()).unwrap();
     let start = time::Instant::now();
     let mut nread = 0;
     while nread < target {

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -19,6 +19,7 @@ use baz::FutureServiceExt as BazExt;
 use futures::Future;
 use tarpc::util::{FirstSocketAddr, Never};
 use tarpc::sync::Connect;
+use tarpc::{ClientConfig, ServerConfig};
 
 mod bar {
     service! {
@@ -31,7 +32,7 @@ struct Bar;
 impl bar::FutureService for Bar {
     type BarFut = futures::Finished<i32, Never>;
 
-    fn bar(&mut self, i: i32) -> Self::BarFut {
+    fn bar(&self, i: i32) -> Self::BarFut {
         futures::finished(i)
     }
 }
@@ -47,7 +48,7 @@ struct Baz;
 impl baz::FutureService for Baz {
     type BazFut = futures::Finished<String, Never>;
 
-    fn baz(&mut self, s: String) -> Self::BazFut {
+    fn baz(&self, s: String) -> Self::BazFut {
         futures::finished(format!("Hello, {}!", s))
     }
 }
@@ -58,11 +59,11 @@ macro_rules! pos {
 
 fn main() {
     let _ = env_logger::init();
-    let bar_addr = Bar.listen("localhost:0".first_socket_addr()).wait().unwrap();
-    let baz_addr = Baz.listen("localhost:0".first_socket_addr()).wait().unwrap();
+    let bar_addr = Bar.listen("localhost:0".first_socket_addr(), ServerConfig::new_tcp()).wait().unwrap();
+    let baz_addr = Baz.listen("localhost:0".first_socket_addr(), ServerConfig::new_tcp()).wait().unwrap();
 
-    let mut bar_client = bar::SyncClient::connect(&bar_addr).unwrap();
-    let mut baz_client = baz::SyncClient::connect(&baz_addr).unwrap();
+    let bar_client = bar::SyncClient::connect(&bar_addr, ClientConfig::new_tcp()).unwrap();
+    let baz_client = baz::SyncClient::connect(&baz_addr, ClientConfig::new_tcp()).unwrap();
 
     info!("Result: {:?}", bar_client.bar(17));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 //!
 //! use tarpc::sync::Connect;
 //! use tarpc::util::Never;
+//! use tarpc::{ClientConfig, ServerConfig};
 //!
 //! service! {
 //!     rpc hello(name: String) -> String;
@@ -46,15 +47,15 @@
 //! struct HelloServer;
 //!
 //! impl SyncService for HelloServer {
-//!     fn hello(&mut self, name: String) -> Result<String, Never> {
+//!     fn hello(&self, name: String) -> Result<String, Never> {
 //!         Ok(format!("Hello, {}!", name))
 //!     }
 //! }
 //!
 //! fn main() {
 //!     let addr = "localhost:10000";
-//!     let _server = HelloServer.listen(addr);
-//!     let mut client = SyncClient::connect(addr).unwrap();
+//!     let _server = HelloServer.listen(addr, ServerConfig::default());
+//!     let mut client = SyncClient::connect(addr, ClientConfig::default()).unwrap();
 //!     println!("{}", client.hello("Mom".to_string()).unwrap());
 //! }
 //! ```
@@ -83,7 +84,7 @@
 //! struct HelloServer;
 //!
 //! impl SyncService for HelloServer {
-//!     fn hello(&mut self, name: String) -> Result<String, Never> {
+//!     fn hello(&self, name: String) -> Result<String, Never> {
 //!         Ok(format!("Hello, {}!", name))
 //!     }
 //! }

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use std::io;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
-use tokio_core::io::Io;
 use tokio_core::net::TcpListener;
 use tokio_core::reactor::Handle;
 use tokio_proto::BindServer;
@@ -126,31 +125,38 @@ impl Listen for Config<Tls> {
 }
 
 /// TODO:
-pub struct Config<S>
-    where S: Io
-{
+pub struct Config<S> {
     #[cfg(feature = "tls")]
     tls_acceptor: Option<TlsAcceptor>,
     _client_stream: PhantomData<S>,
 }
 
 #[cfg(feature = "tls")]
-impl<S> Config<S>
-    where S: Io
-{
+impl<S> Default for Config<S> {
+    fn default() -> Self {
+        Config {
+            tls_acceptor: None,
+            _client_stream: PhantomData,
+        }
+    }
+}
+
+#[cfg(not(feature = "tls"))]
+impl<S> Default for Config<S> {
+    fn default() -> Self {
+        Config {
+            _client_stream: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "tls")]
+impl Config<Tcp> {
     /// TODO
-    pub fn new_tcp() -> Config<Tcp> {
+    pub fn new_tcp() -> Self {
         Config {
             _client_stream: PhantomData,
             tls_acceptor: None,
-        }
-    }
-
-    /// TODO
-    pub fn new_tls(tls_acceptor: TlsAcceptor) -> Config<Tls> {
-        Config {
-            _client_stream: PhantomData,
-            tls_acceptor: Some(tls_acceptor),
         }
     }
 }
@@ -158,8 +164,19 @@ impl<S> Config<S>
 #[cfg(not(feature = "tls"))]
 impl Config<Tcp> {
     /// TODO
-    pub fn new_tcp() -> Config<Tcp> {
+    pub fn new_tcp() -> Self {
         Config { _client_stream: PhantomData }
+    }
+}
+
+#[cfg(feature = "tls")]
+impl Config<Tls> {
+    /// TODO
+    pub fn new_tls(tls_acceptor: TlsAcceptor) -> Self {
+        Config {
+            _client_stream: PhantomData,
+            tls_acceptor: Some(tls_acceptor),
+        }
     }
 }
 


### PR DESCRIPTION
I think the problem you were running into is related to the fact that `tarpc::Client` only impls `Connect` when the `Io` type is `TcpStream` or `TlsStream`. I haven't exactly solved that issue in this PR. Instead I just stopped using the Connect futures in the macro. We should fix this before merging upstream, but at least it compiles now.

I also:
1. Made the generated traits take `&self` again.
2. Added impls for `Default` to the config structs.
2. Made `TcpStream` the default type of the `S` type parameter on the clients.
3. Fixed the tests/examples.