### PR TITLE
Remove type param on client::Config

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -70,10 +70,12 @@ run_cargo() {
                     rustup run $2 cargo $1 &>/dev/null
                 else
                     rustup run nightly cargo $1 --features unstable &>/dev/null
+                    rustup run nightly cargo $1 --features unstable,tls &>/dev/null
                 fi
 	else
 		printf "${PREFIX} $VERB... "
 		cargo $1 &>/dev/null
+		cargo $1 --features tls &>/dev/null
 	fi
 	if [ "$?" != "0" ]; then
 		printf "${FAILURE}\n"

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,21 +10,25 @@ use protocol::Proto;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::io;
-use std::marker::PhantomData;
 use tokio_core::io::Io;
 use tokio_core::net::TcpStream;
 use tokio_proto::BindClient as ProtoBindClient;
 use tokio_proto::multiplex::Multiplex;
 use tokio_service::Service;
 
+#[cfg(feature = "tls")]
+use self::tls::*;
+#[cfg(feature = "tls")]
+use tokio_tls::{TlsStream};
+
+
 type WireResponse<Resp, E> = Result<Result<Resp, WireError<E>>, DeserializeError>;
-type BindClient<Req, Resp, E, S> = <Proto<Req, Result<Resp, WireError<E>>> as ProtoBindClient<Multiplex, S>>::BindClient;
+type BindClient<Req, Resp, E> = <Proto<Req, Result<Resp, WireError<E>>> as ProtoBindClient<Multiplex, Either>>::BindClient;
 
 #[cfg(feature = "tls")]
 pub mod tls {
     use native_tls::TlsConnector;
     use super::*;
-    use tokio_tls::TlsStream;
 
     /// TLS context
     pub struct TlsClientContext {
@@ -46,54 +50,97 @@ pub mod tls {
         }
     }
 
-    impl Config<TlsStream<TcpStream>> {
-        /// Construct a new `Config<TlsStream<TcpStream>>`
+    impl Config {
+        /// Construct a new `Config`
         pub fn new_tls(tls_client_cx: TlsClientContext) -> Self {
             Config {
-                _stream: PhantomData,
                 tls_client_cx: Some(tls_client_cx),
             }
         }
     }
 }
 
-#[cfg(feature = "tls")]
-use self::tls::*;
-
 /// A client that impls `tokio_service::Service` that writes and reads bytes.
 ///
 /// Typically, this would be combined with a serialization pre-processing step
 /// and a deserialization post-processing step.
-pub struct Client<Req, Resp, E, S=TcpStream>
+pub struct Client<Req, Resp, E>
     where Req: Serialize + 'static,
           Resp: Deserialize + 'static,
           E: Deserialize + 'static,
-          S: Io + 'static
 {
-    inner: BindClient<Req, Resp, E, S>,
+    inner: BindClient<Req, Resp, E>,
 }
 
-impl<Req, Resp, E, S> Clone for Client<Req, Resp, E, S>
+#[derive(Debug)]
+pub enum Either {
+    Tcp(TcpStream),
+    #[cfg(feature = "tls")]
+    Tls(TlsStream<TcpStream>),
+}
+
+impl From<TcpStream> for Either {
+    fn from(stream: TcpStream) -> Self {
+        Either::Tcp(stream)
+    }
+}
+
+#[cfg(feature = "tls")]
+impl From<TlsStream<TcpStream>> for Either {
+    fn from(stream: TlsStream<TcpStream>) -> Self {
+        Either::Tls(stream)
+    }
+}
+
+impl io::Read for Either {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match *self {
+            Either::Tcp(ref mut stream) => stream.read(buf),
+            #[cfg(feature = "tls")]
+            Either::Tls(ref mut stream) => stream.read(buf),
+        }
+    }
+}
+
+impl io::Write for Either {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match *self {
+            Either::Tcp(ref mut stream) => stream.write(buf),
+            #[cfg(feature = "tls")]
+            Either::Tls(ref mut stream) => stream.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match *self {
+            Either::Tcp(ref mut stream) => stream.flush(),
+            #[cfg(feature = "tls")]
+            Either::Tls(ref mut stream) => stream.flush(),
+        }
+    }
+}
+
+impl Io for Either { }
+
+impl<Req, Resp, E> Clone for Client<Req, Resp, E>
     where Req: Serialize + 'static,
           Resp: Deserialize + 'static,
           E: Deserialize + 'static,
-          S: Io + 'static
 {
     fn clone(&self) -> Self {
         Client { inner: self.inner.clone() }
     }
 }
 
-impl<Req, Resp, E, I> Service for Client<Req, Resp, E, I>
+impl<Req, Resp, E> Service for Client<Req, Resp, E>
     where Req: Serialize + Sync + Send + 'static,
           Resp: Deserialize + Sync + Send + 'static,
           E: Deserialize + Sync + Send + 'static,
-          I: Io + 'static,
 {
     type Request = Req;
     type Response = Result<Resp, ::Error<E>>;
     type Error = io::Error;
-    type Future = futures::Map<<BindClient<Req, Resp, E, I> as Service>::Future,
+    type Future = futures::Map<<BindClient<Req, Resp, E> as Service>::Future,
                  fn(WireResponse<Resp, E>) -> Result<Resp, ::Error<E>>>;
 
     fn call(&self, request: Self::Request) -> Self::Future {
@@ -101,17 +148,15 @@ impl<Req, Resp, E, I> Service for Client<Req, Resp, E, I>
     }
 }
 
-impl<Req, Resp, E, S> Client<Req, Resp, E, S>
+impl<Req, Resp, E> Client<Req, Resp, E>
     where Req: Serialize + 'static,
           Resp: Deserialize + 'static,
           E: Deserialize + 'static,
-          S: Io + 'static
 {
-    fn new(inner: BindClient<Req, Resp, E, S>) -> Self
+    fn new(inner: BindClient<Req, Resp, E>) -> Self
         where Req: Serialize + Sync + Send + 'static,
               Resp: Deserialize + Sync + Send + 'static,
               E: Deserialize + Sync + Send + 'static,
-              S: Io + 'static
     {
         Client { inner: inner }
     }
@@ -123,81 +168,65 @@ impl<Req, Resp, E, S> Client<Req, Resp, E, S>
     }
 }
 
-impl<Req, Resp, E, S> fmt::Debug for Client<Req, Resp, E, S>
+impl<Req, Resp, E> fmt::Debug for Client<Req, Resp, E>
     where Req: Serialize + 'static,
           Resp: Deserialize + 'static,
           E: Deserialize + 'static,
-          S: Io + 'static
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "Client {{ .. }}")
     }
 }
 
-/// TODO:
-pub struct Config<S> {
-    _stream: PhantomData<S>,
+/// Client configuration when connecting.
+#[derive(Default)]
+pub struct Config {
     #[cfg(feature = "tls")]
+    /// Tls configuration
     tls_client_cx: Option<TlsClientContext>,
 }
 
 #[cfg(feature = "tls")]
-impl<S> Default for Config<S> {
-    fn default() -> Self {
+impl Config {
+    /// Construct a new `Config`
+    pub fn new_tcp() -> Self {
         Config {
-            _stream: PhantomData,
             tls_client_cx: None,
         }
     }
 }
 
 #[cfg(not(feature = "tls"))]
-impl<S> Default for Config<S> {
-    fn default() -> Self {
-        Config {
-            _stream: PhantomData,
-        }
-    }
-}
-
-#[cfg(feature = "tls")]
-impl Config<TcpStream> {
-    /// Construct a new `Config<TcpStream>`
+impl Config {
+    /// Construct a new `Config`
     pub fn new_tcp() -> Self {
-        Config {
-            _stream: PhantomData,
-            tls_client_cx: None,
-        }
-    }
-}
-
-#[cfg(not(feature = "tls"))]
-impl Config<TcpStream> {
-    /// Construct a new `Config<TcpStream>`
-    pub fn new_tcp() -> Self {
-        Config { _stream: PhantomData }
+        Config { }
     }
 }
 
 /// Exposes a trait for connecting asynchronously to servers.
 pub mod future {
     use future::REMOTE;
-    use futures::{self, Async, Future};
+    use futures::{self, Async, Future, future};
     use protocol::Proto;
     use serde::{Deserialize, Serialize};
     use std::io;
     use std::marker::PhantomData;
     use std::net::SocketAddr;
-    use super::{Client, Config};
-    use tokio_core::io::Io;
+    use super::{Client, Config, Either};
     use tokio_core::net::TcpStream;
     use tokio_core::reactor;
     use tokio_proto::BindClient;
+    use tokio_core::net::TcpStreamNew;
+    #[cfg(feature = "tls")]
+    use super::tls::TlsClientContext;
+    #[cfg(feature = "tls")]
+    use tokio_tls::{ConnectAsync, TlsStream, TlsConnectorExt};
+    #[cfg(feature = "tls")]
+    use errors::native2io;
 
     /// Types that can connect to a server asynchronously.
-    pub trait Connect<'a, S>: Sized
-        where S: Io
-    {
+    pub trait Connect<'a>: Sized {
         /// The type of the future returned when calling `connect`.
         type ConnectFut: Future<Item = Self, Error = io::Error> + 'static;
 
@@ -205,7 +234,7 @@ pub mod future {
         type ConnectWithFut: Future<Item = Self, Error = io::Error> + 'a;
         /// Connects to a server located at the given address, using a remote to the default
         /// reactor.
-        fn connect(addr: &SocketAddr, config: Config<S>) -> Self::ConnectFut {
+        fn connect(addr: &SocketAddr, config: Config) -> Self::ConnectFut {
             Self::connect_remotely(addr, &REMOTE, config)
         }
 
@@ -213,130 +242,141 @@ pub mod future {
         /// remote.
         fn connect_remotely(addr: &SocketAddr,
                             remote: &reactor::Remote,
-                            config: Config<S>)
+                            config: Config)
                             -> Self::ConnectFut;
 
         /// Connects to a server located at the given address, using the given reactor
         /// handle.
         fn connect_with(addr: &SocketAddr,
                         handle: &'a reactor::Handle,
-                        config: Config<S>)
+                        config: Config)
                         -> Self::ConnectWithFut;
     }
 
     /// A future that resolves to a `Client` or an `io::Error`.
-    pub struct ConnectWithFuture<'a, Req, Resp, E, S, F>
-        where S: Io,
-              F: Future<Item = S, Error = io::Error>
+    pub struct ConnectWithFuture<'a, Req, Resp, E, F>
+        where F: Future
     {
         inner: futures::Map<F, MultiplexConnect<'a, Req, Resp, E>>,
     }
 
-    #[cfg(feature = "tls")]
-    mod tls {
-        use errors::native2io;
-        use super::*;
-        use super::super::tls::TlsClientContext;
-        use tokio_core::net::TcpStreamNew;
-        use tokio_tls::{ConnectAsync, TlsStream, TlsConnectorExt};
+    /// Provides the connection Fn impl for Tls
+    pub struct ConnectFn {
+        #[cfg(feature = "tls")]
+        tls_ctx: Option<TlsClientContext>
+    }
 
-        /// Provides the connection Fn impl for Tls
-        pub struct TlsConnectFn;
+    impl FnOnce<(TcpStream,)> for ConnectFn {
+        #[cfg(feature = "tls")]
+        type Output = future::Either<
+            future::FutureResult<Either, io::Error>,
+            futures::Map<
+                futures::MapErr<
+                    ConnectAsync<TcpStream>,
+                    fn(::native_tls::Error) -> io::Error>,
+                fn(TlsStream<TcpStream>) -> Either>>;
+        #[cfg(not(feature = "tls"))]
+        type Output = future::FutureResult<Either, io::Error>;
 
-        impl FnOnce<(((TcpStream, TlsClientContext),))> for TlsConnectFn {
-            type Output = futures::MapErr<ConnectAsync<TcpStream>,
-                            fn(::native_tls::Error) -> io::Error>;
-
-            extern "rust-call" fn call_once(self,
-                                            ((tcp, tls_client_cx),): ((TcpStream,
-                                                                       TlsClientContext),))
-                                            -> Self::Output {
-                tls_client_cx.tls_connector
+        extern "rust-call" fn call_once(self, (tcp,): (TcpStream,)) -> Self::Output {
+            #[cfg(feature = "tls")]
+            match self.tls_ctx {
+                None => future::Either::A(future::ok(Either::from(tcp))),
+                Some(tls_client_cx) => future::Either::B(tls_client_cx.tls_connector
                     .connect_async(&tls_client_cx.domain, tcp)
-                    .map_err(native2io)
+                    .map_err(native2io as fn(_) -> _)
+                    .map(Either::from as fn(_) -> _)),
             }
+            #[cfg(not(feature = "tls"))]
+            future::ok(Either::from(tcp))
+        }
+    }
+
+    type ConnectFut =
+        futures::AndThen<TcpStreamNew,
+                         <ConnectFn as FnOnce<(TcpStream,)>>::Output,
+                         ConnectFn>;
+
+
+    impl<'a, Req, Resp, E> Connect<'a> for Client<Req, Resp, E>
+        where Req: Serialize + Sync + Send + 'static,
+              Resp: Deserialize + Sync + Send + 'static,
+              E: Deserialize + Sync + Send + 'static
+    {
+        type ConnectFut = ConnectFuture<Req, Resp, E>;
+        type ConnectWithFut = ConnectWithFuture<'a,
+                          Req,
+                          Resp,
+                          E,
+                          ConnectFut>;
+
+        fn connect_remotely(addr: &SocketAddr,
+                            remote: &reactor::Remote,
+                            _config: Config) -> Self::ConnectFut {
+            let addr = *addr;
+            let (tx, rx) = futures::oneshot();
+            remote.spawn(move |handle| {
+                let handle2 = handle.clone();
+                TcpStream::connect(&addr, handle)
+                    .and_then(move |socket| {
+                        #[cfg(feature = "tls")]
+                        match _config.tls_client_cx {
+                            Some(tls_client_cx) => {
+                                future::Either::A(tls_client_cx.tls_connector
+                                    .connect_async(&tls_client_cx.domain, socket)
+                                    .map(Either::Tls)
+                                    .map_err(native2io))
+                            }
+                            None => future::Either::B(future::ok(Either::Tcp(socket))),
+                        }
+                        #[cfg(not(feature = "tls"))]
+                        future::ok(Either::Tcp(socket))
+                    })
+                    .map(move |tcp| Client::new(Proto::new().bind_client(&handle2, tcp)))
+                    .then(move |result| {
+                        tx.complete(result);
+                        Ok(())
+                    })
+            });
+            ConnectFuture { inner: rx }
         }
 
-        type TlsConnectFut =
-            futures::AndThen<futures::Join<TcpStreamNew,
-                                           futures::future::FutureResult<TlsClientContext,
-                                                                         io::Error>>,
-                             futures::MapErr<ConnectAsync<TcpStream>,
-                                             fn(::native_tls::Error) -> io::Error>,
-                             TlsConnectFn>;
-
-        impl<'a, Req, Resp, E> Connect<'a, TlsStream<TcpStream>>
-            for Client<Req, Resp, E, TlsStream<TcpStream>>
-            where Req: Serialize + Sync + Send + 'static,
-                  Resp: Deserialize + Sync + Send + 'static,
-                  E: Deserialize + Sync + Send + 'static
-        {
-            type ConnectFut = ConnectFuture<Req, Resp, E, TlsStream<TcpStream>>;
-            type ConnectWithFut = ConnectWithFuture<'a,
-                              Req,
-                              Resp,
-                              E,
-                              TlsStream<TcpStream>,
-                              TlsConnectFut>;
-
-            fn connect_remotely(addr: &SocketAddr,
-                                remote: &reactor::Remote,
-                                config: Config<TlsStream<TcpStream>>)
-                                -> Self::ConnectFut {
-                let addr = *addr;
-                let (tx, rx) = futures::oneshot();
-                remote.spawn(move |handle| {
-                    let handle2 = handle.clone();
-                    TcpStream::connect(&addr, handle)
-                        .and_then(move |socket| {
-                            let tls_client_cx = config.tls_client_cx
-                                .expect("Need TlsClientContext for a TlsStream");
-                            tls_client_cx.tls_connector
-                                .connect_async(&tls_client_cx.domain, socket)
-                                .map_err(native2io)
-                        })
-                        .map(move |tcp| Client::new(Proto::new().bind_client(&handle2, tcp)))
-                        .then(move |result| {
-                            tx.complete(result);
-                            Ok(())
-                        })
-                });
-                ConnectFuture { inner: rx }
-            }
-
-            fn connect_with(addr: &SocketAddr,
-                            handle: &'a reactor::Handle,
-                            config: Config<TlsStream<TcpStream>>)
-                            -> Self::ConnectWithFut {
-                let tls_client_cx = config.tls_client_cx
-                    .expect("Need TlsClientContext for a TlsStream");
-                ConnectWithFuture {
-                    inner: TcpStream::connect(addr, handle)
-                        .join(futures::finished(tls_client_cx))
-                        .and_then(TlsConnectFn)
-                        .map(MultiplexConnect::new(handle)),
-                }
-            }
+        fn connect_with(addr: &SocketAddr,
+                        handle: &'a reactor::Handle,
+                        _config: Config)
+                        -> Self::ConnectWithFut {
+            #[cfg(feature = "tls")]
+            return ConnectWithFuture {
+                inner: TcpStream::connect(addr, handle)
+                    .and_then(ConnectFn {
+                        tls_ctx: _config.tls_client_cx,
+                    })
+                    .map(MultiplexConnect::new(handle))
+            };
+            #[cfg(not(feature = "tls"))]
+            return ConnectWithFuture {
+                inner: TcpStream::connect(addr, handle)
+                    .and_then(ConnectFn {})
+                    .map(MultiplexConnect::new(handle))
+            };
         }
     }
 
     /// A future that resolves to a `Client` or an `io::Error`.
-    pub struct ConnectFuture<Req, Resp, E, S>
+    pub struct ConnectFuture<Req, Resp, E>
         where Req: Serialize + 'static,
               Resp: Deserialize + 'static,
               E: Deserialize + 'static,
-              S: Io + 'static
     {
-        inner: futures::Oneshot<io::Result<Client<Req, Resp, E, S>>>,
+        inner: futures::Oneshot<io::Result<Client<Req, Resp, E>>>,
     }
 
-    impl<Req, Resp, E, S> Future for ConnectFuture<Req, Resp, E, S>
+    impl<Req, Resp, E> Future for ConnectFuture<Req, Resp, E>
         where Req: Serialize + 'static,
               Resp: Deserialize + 'static,
               E: Deserialize + 'static,
-              S: Io + 'static
     {
-        type Item = Client<Req, Resp, E, S>;
+        type Item = Client<Req, Resp, E>;
         type Error = io::Error;
 
         fn poll(&mut self) -> futures::Poll<Self::Item, Self::Error> {
@@ -349,14 +389,14 @@ pub mod future {
         }
     }
 
-    impl<'a, Req, Resp, E, S, F> Future for ConnectWithFuture<'a, Req, Resp, E, S, F>
+    impl<'a, Req, Resp, E, F, I> Future for ConnectWithFuture<'a, Req, Resp, E, F>
         where Req: Serialize + Sync + Send + 'static,
               Resp: Deserialize + Sync + Send + 'static,
               E: Deserialize + Sync + Send + 'static,
-              S: Io + 'static,
-              F: Future<Item = S, Error = io::Error>
+              F: Future<Item = I, Error = io::Error>,
+              I: Into<Either>
     {
-        type Item = Client<Req, Resp, E, S>;
+        type Item = Client<Req, Resp, E>;
         type Error = io::Error;
 
         fn poll(&mut self) -> futures::Poll<Self::Item, Self::Error> {
@@ -372,57 +412,16 @@ pub mod future {
         }
     }
 
-    impl<'a, Req, Resp, E, S> FnOnce<(S,)> for MultiplexConnect<'a, Req, Resp, E>
+    impl<'a, Req, Resp, E, I> FnOnce<(I,)> for MultiplexConnect<'a, Req, Resp, E>
         where Req: Serialize + Sync + Send + 'static,
               Resp: Deserialize + Sync + Send + 'static,
               E: Deserialize + Sync + Send + 'static,
-              S: Io + 'static
+              I: Into<Either>,
     {
-        type Output = Client<Req, Resp, E, S>;
+        type Output = Client<Req, Resp, E>;
 
-        extern "rust-call" fn call_once(self, (s,): (S,)) -> Self::Output {
-            Client::new(Proto::new().bind_client(self.0, s))
-        }
-    }
-
-    impl<'a, Req, Resp, E> Connect<'a, TcpStream> for Client<Req, Resp, E, TcpStream>
-        where Req: Serialize + Sync + Send + 'static,
-              Resp: Deserialize + Sync + Send + 'static,
-              E: Deserialize + Sync + Send + 'static
-    {
-        type ConnectFut = ConnectFuture<Req, Resp, E, TcpStream>;
-        type ConnectWithFut = ConnectWithFuture<'a,
-                          Req,
-                          Resp,
-                          E,
-                          TcpStream,
-                          ::tokio_core::net::TcpStreamNew>;
-
-        fn connect_remotely(addr: &SocketAddr,
-                            remote: &reactor::Remote,
-                            _config: Config<TcpStream>)
-                            -> Self::ConnectFut {
-            let addr = *addr;
-            let (tx, rx) = futures::oneshot();
-            remote.spawn(move |handle| {
-                let handle2 = handle.clone();
-                TcpStream::connect(&addr, handle)
-                    .map(move |tcp| Client::new(Proto::new().bind_client(&handle2, tcp)))
-                    .then(move |result| {
-                        tx.complete(result);
-                        Ok(())
-                    })
-            });
-            ConnectFuture { inner: rx }
-        }
-
-        fn connect_with(addr: &SocketAddr,
-                        handle: &'a reactor::Handle,
-                        _config: Config<TcpStream>)
-                        -> Self::ConnectWithFut {
-            ConnectWithFuture {
-                inner: TcpStream::connect(addr, handle).map(MultiplexConnect::new(handle)),
-            }
+        extern "rust-call" fn call_once(self, (stream,): (I,)) -> Self::Output {
+            Client::new(Proto::new().bind_client(self.0, stream.into()))
         }
     }
 }
@@ -434,23 +433,19 @@ pub mod sync {
     use std::io;
     use std::net::ToSocketAddrs;
     use super::{Client, Config};
-    use tokio_core::io::Io;
-    use tokio_core::net::TcpStream;
 
     /// Types that can connect to a server synchronously.
-    pub trait Connect<S>: Sized
-        where S: Io
-    {
+    pub trait Connect: Sized {
         /// Connects to a server located at the given address.
-        fn connect<A>(addr: A, config: Config<S>) -> Result<Self, io::Error> where A: ToSocketAddrs;
+        fn connect<A>(addr: A, config: Config) -> Result<Self, io::Error> where A: ToSocketAddrs;
     }
 
-    impl<Req, Resp, E> Connect<TcpStream> for Client<Req, Resp, E, TcpStream>
+    impl<Req, Resp, E> Connect for Client<Req, Resp, E>
         where Req: Serialize + Sync + Send + 'static,
               Resp: Deserialize + Sync + Send + 'static,
               E: Deserialize + Sync + Send + 'static
     {
-        fn connect<A>(addr: A, config: Config<TcpStream>) -> Result<Self, io::Error>
+        fn connect<A>(addr: A, config: Config) -> Result<Self, io::Error>
             where A: ToSocketAddrs
         {
             let addr = if let Some(a) = addr.to_socket_addrs()?.next() {
@@ -460,32 +455,7 @@ pub mod sync {
                                           "`ToSocketAddrs::to_socket_addrs` returned an empty \
                                            iterator."));
             };
-            <Self as super::future::Connect<TcpStream>>::connect(&addr, config).wait()
+            <Self as super::future::Connect>::connect(&addr, config).wait()
         }
-    }
-
-    cfg_if! {
-        if #[cfg(feature = "tls")] {
-            use ::tokio_tls::TlsStream;
-
-            impl<Req, Resp, E> Connect<TlsStream<TcpStream>> for Client<Req, Resp, E, TlsStream<TcpStream>>
-                where Req: Serialize + Sync + Send + 'static,
-                      Resp: Deserialize + Sync + Send + 'static,
-                      E: Deserialize + Sync + Send + 'static
-            {
-                fn connect<A>(addr: A, config: Config<TlsStream<TcpStream>>) -> Result<Self, io::Error>
-                    where A: ToSocketAddrs
-                {
-                    let addr = if let Some(a) = addr.to_socket_addrs()?.next() {
-                        a
-                    } else {
-                        return Err(io::Error::new(io::ErrorKind::AddrNotAvailable,
-                                                  "`ToSocketAddrs::to_socket_addrs` returned an \
-                                                   empty iterator."));
-                    };
-                    <Self as super::future::Connect<TlsStream<TcpStream>>>::connect(&addr, config).wait()
-                }
-            }
-        } else {}
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,8 @@ pub mod util;
 #[macro_use]
 mod macros;
 /// Provides the base client stubs used by the service macro.
-mod client;
+#[doc(hidden)]
+pub mod client;
 /// Provides the base server boilerplate used by service implementations.
 mod server;
 /// Provides implementations of `ClientProto` and `ServerProto` that implement the tarpc protocol.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -621,27 +621,23 @@ macro_rules! service {
         #[allow(unused)]
         #[derive(Clone, Debug)]
         /// The client stub that makes RPC calls to the server. Exposes a blocking interface.
-        pub struct SyncClient<S=$crate::tokio_core::net::TcpStream>(FutureClient<S>)
-            where S: $crate::tokio_core::io::Io + 'static;
-                  // $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>: $crate::future::Connect<'a, S>;
+        pub struct SyncClient(FutureClient);
 
-        impl<S> $crate::sync::Connect<S> for SyncClient<S>
-            where S: $crate::tokio_core::io::Io + 'static,
-                  $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>: $crate::future::Connect<'static, S> {
-            fn connect<A>(addr: A, config: $crate::ClientConfig<S>) -> ::std::result::Result<Self, ::std::io::Error>
+        impl $crate::sync::Connect for SyncClient
+            where $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error>: $crate::future::Connect<'static> {
+            fn connect<A>(addr: A, config: $crate::ClientConfig) -> ::std::result::Result<Self, ::std::io::Error>
                 where A: ::std::net::ToSocketAddrs,
             {
                 let addr = $crate::util::FirstSocketAddr::try_first_socket_addr(&addr)?;
-                let client = <FutureClient<S> as $crate::future::Connect<'static, S>>::connect(&addr, config);
+                let client = <FutureClient as $crate::future::Connect<'static>>::connect(&addr, config);
                 let client = $crate::futures::Future::wait(client)?;
                 let client = SyncClient(client);
                 ::std::result::Result::Ok(client)
             }
         }
 
-        impl<S> SyncClient<S>
-            where S: $crate::tokio_core::io::Io + 'static,
-                  $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>: $crate::sync::Connect<S>
+        impl SyncClient
+            where $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error>: $crate::sync::Connect
         {
             $(
                 #[allow(unused)]
@@ -656,27 +652,23 @@ macro_rules! service {
         }
 
         #[allow(non_camel_case_types)]
-        type __tarpc_service_Client<S> =
+        type __tarpc_service_Client =
             $crate::Client<__tarpc_service_Request,
                            __tarpc_service_Response,
-                           __tarpc_service_Error,
-                           S>;
+                           __tarpc_service_Error>;
 
         #[allow(non_camel_case_types)]
         /// Implementation detail: Pending connection.
-        pub struct __tarpc_service_ConnectFuture<T, S>
-            where S: $crate::tokio_core::io::Io + 'static {
-                  // $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>: $crate::future::Connect<'static, S> {
+        pub struct __tarpc_service_ConnectFuture<T> {
+                  // $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error>: $crate::future::Connect<'static> {
             inner: $crate::futures::Map<$crate::ConnectFuture<__tarpc_service_Request,
                                                               __tarpc_service_Response,
-                                                              __tarpc_service_Error,
-                                                              S>,
-                                        fn(__tarpc_service_Client<S>) -> T>,
+                                                              __tarpc_service_Error>,
+                                        fn(__tarpc_service_Client) -> T>,
         }
 
-        impl<T, S> $crate::futures::Future for __tarpc_service_ConnectFuture<T, S>
-            where S: $crate::tokio_core::io::Io + 'static {
-                  // $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>: $crate::future::Connect<'static, S> {
+        impl<T> $crate::futures::Future for __tarpc_service_ConnectFuture<T> {
+                  // $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error>: $crate::future::Connect<'static> {
             type Item = T;
             type Error = ::std::io::Error;
 
@@ -687,26 +679,21 @@ macro_rules! service {
 
         #[allow(non_camel_case_types)]
         /// Implementation detail: Pending connection.
-        pub struct __tarpc_service_ConnectWithFuture<'a, T, S>
-            where S: $crate::tokio_core::io::Io + 'static + Sized,
-                  $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>: $crate::future::Connect<'a, S>,
-                  // F: $crate::futures::Future<Item = S, Error = ::std::io::Error>
-            {
+        pub struct __tarpc_service_ConnectWithFuture<'a, T>
+            where $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error>: $crate::future::Connect<'a>,
+        {
             inner: $crate::futures::Map<$crate::ConnectWithFuture<'a,
                                                                   __tarpc_service_Request,
                                                                   __tarpc_service_Response,
                                                                   __tarpc_service_Error,
-                                                                  S,
                                                                   // FIXME: shouldn't need box here
                                                                   // I don' think...
-                                                                  ::std::boxed::Box<$crate::futures::Future<Item = S, Error = ::std::io::Error>>>,
-                                        fn(__tarpc_service_Client<S>) -> T>,
+                                                                  ::std::boxed::Box<$crate::futures::Future<Item = $crate::client::Either, Error = ::std::io::Error>>>,
+                                        fn(__tarpc_service_Client) -> T>,
         }
 
-        impl<'a, T, S> $crate::futures::Future for __tarpc_service_ConnectWithFuture<'a, T, S>
-            where S: $crate::tokio_core::io::Io + 'static,
-                  $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>: $crate::future::Connect<'a, S>,
-                  // F: $crate::futures::Future<Item = S, Error = ::std::io::Error>
+        impl<'a, T> $crate::futures::Future for __tarpc_service_ConnectWithFuture<'a, T>
+            where $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error>: $crate::future::Connect<'a>,
         {
             type Item = T;
             type Error = ::std::io::Error;
@@ -719,35 +706,31 @@ macro_rules! service {
         #[allow(unused)]
         #[derive(Clone, Debug)]
         /// The client stub that makes RPC calls to the server. Exposes a Future interface.
-        pub struct FutureClient<S=$crate::tokio_core::net::TcpStream>(__tarpc_service_Client<S>)
-        where S: $crate::tokio_core::io::Io + 'static;
+        pub struct FutureClient(__tarpc_service_Client);
 
-        impl<'a, S> $crate::future::Connect<'a, S> for FutureClient<S>
-            where S: $crate::tokio_core::io::Io + 'a,
-                  $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>: $crate::future::Connect<'a, S>,
-                  // F: $crate::futures::Future<Item = S, Error = ::std::io::Error>
-                  {
+        impl<'a> $crate::future::Connect<'a> for FutureClient
+            where $crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error>: $crate::future::Connect<'a>,
+        {
             type ConnectFut = $crate::futures::Map<<$crate::Client<__tarpc_service_Request,
                                                                    __tarpc_service_Response,
-                                                                   __tarpc_service_Error,
-                                                                   S>
-                                                   as $crate::future::Connect<'a, S>>::ConnectFut,
-                                                   fn($crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error, S>) -> FutureClient<S>>;
+                                                                   __tarpc_service_Error>
+                                                   as $crate::future::Connect<'a>>::ConnectFut,
+                                                   fn($crate::Client<__tarpc_service_Request, __tarpc_service_Response, __tarpc_service_Error>) -> FutureClient>;
             type ConnectWithFut = $crate::futures::Map<<$crate::Client<__tarpc_service_Request,
                                 __tarpc_service_Response,
-                                __tarpc_service_Error, S> as
-                 $crate::future::Connect<'a, S>>::ConnectWithFut,
+                                __tarpc_service_Error> as
+                 $crate::future::Connect<'a>>::ConnectWithFut,
                  fn($crate::Client<__tarpc_service_Request,
                                   __tarpc_service_Response,
-                                  __tarpc_service_Error, S>)
-                     -> FutureClient<S>>;
+                                  __tarpc_service_Error>)
+                     -> FutureClient>;
 
             fn connect_remotely(__tarpc_service_addr: &::std::net::SocketAddr,
                                 __tarpc_service_remote: &$crate::tokio_core::reactor::Remote,
-                                __tarpc_client_config: $crate::ClientConfig<S>)
+                                __tarpc_client_config: $crate::ClientConfig)
                 -> Self::ConnectFut
             {
-                let client = <__tarpc_service_Client<S> as $crate::future::Connect<'a, S>>::connect_remotely(
+                let client = <__tarpc_service_Client as $crate::future::Connect<'a>>::connect_remotely(
                     __tarpc_service_addr, __tarpc_service_remote, __tarpc_client_config);
 
                 $crate::futures::Future::map(client, FutureClient)
@@ -755,19 +738,17 @@ macro_rules! service {
 
             fn connect_with(__tarpc_service_addr: &::std::net::SocketAddr,
                             __tarpc_service_handle: &'a $crate::tokio_core::reactor::Handle,
-                            __tarpc_client_config: $crate::ClientConfig<S>)
+                            __tarpc_client_config: $crate::ClientConfig)
                 -> Self::ConnectWithFut
             {
-                let client = <__tarpc_service_Client<S> as $crate::future::Connect<'a, S>>::connect_with(
+                let client = <__tarpc_service_Client as $crate::future::Connect<'a>>::connect_with(
                     __tarpc_service_addr, __tarpc_service_handle, __tarpc_client_config);
 
                 $crate::futures::Future::map(client, FutureClient)
             }
         }
 
-        impl<S> FutureClient<S>
-            where S: $crate::tokio_core::io::Io + 'static,
-        {
+        impl FutureClient {
             $(
                 #[allow(unused)]
                 $(#[$attr])*
@@ -883,7 +864,7 @@ mod functional_test {
             use ::TlsClientContext;
             use ::native_tls::{Pkcs12, TlsAcceptor, TlsConnector};
 
-            fn tls_context() -> (ServerConfig<Tls>, ClientConfig<Tls>) {
+            fn tls_context() -> (ServerConfig<Tls>, ClientConfig) {
                 let buf = include_bytes!("../test/identity.p12");
                 let pkcs12 = t!(Pkcs12::from_der(buf, "mypass"));
                 let acceptor = t!(t!(TlsAcceptor::builder(pkcs12)).build());
@@ -904,7 +885,7 @@ mod functional_test {
                     use self::security_framework::certificate::SecCertificate;
                     use native_tls::backend::security_framework::TlsConnectorBuilderExt;
 
-                    fn get_tls_client_config() -> ClientConfig<Tls> {
+                    fn get_tls_client_config() -> ClientConfig {
                         let buf = include_bytes!("../test/root-ca.der");
                         let cert = t!(SecCertificate::from_der(buf));
                         let mut connector = t!(TlsConnector::builder());
@@ -918,11 +899,11 @@ mod functional_test {
                 } else if #[cfg(all(not(target_os = "macos"), not(windows)))] {
                     use native_tls::backend::openssl::TlsConnectorBuilderExt;
 
-                    fn get_tls_client_config() -> ClientConfig<Tls> {
+                    fn get_tls_client_config() -> ClientConfig {
                         let mut connector = t!(TlsConnector::builder());
                         t!(connector.builder_mut()
                            .builder_mut()
-                           .set_ca_file("../test/root-ca.pem"));
+                           .set_ca_file("test/root-ca.pem"));
 
                         ClientConfig::new_tls(TlsClientContext {
                             domain: DOMAIN.into(),
@@ -937,26 +918,26 @@ mod functional_test {
                 }
             }
 
-            fn get_sync_client<C: ::sync::Connect<Tls>>(addr: &::std::net::SocketAddr) -> ::std::io::Result<C> {
+            fn get_sync_client<C: ::sync::Connect>(addr: &::std::net::SocketAddr) -> ::std::io::Result<C> {
                 let client_config = get_tls_client_config();
                 C::connect(addr, client_config)
             }
 
-            fn start_server_with_sync_client<C: ::sync::Connect<Tls>, S: SyncServiceExt>(server: S) -> (::std::net::SocketAddr, ::std::io::Result<C>) {
+            fn start_server_with_sync_client<C: ::sync::Connect, S: SyncServiceExt>(server: S) -> (::std::net::SocketAddr, ::std::io::Result<C>) {
                 let (server_config, client_config) = tls_context();
                 let addr = t!(server.listen("localhost:0".first_socket_addr(), server_config));
                 let client = C::connect(addr, client_config);
                 (addr, client)
             }
 
-            fn start_server_with_async_client<'a, C: ::future::Connect<'a, Tls>, S: FutureServiceExt>(server: S) -> (::std::net::SocketAddr, C) {
+            fn start_server_with_async_client<'a, C: ::future::Connect<'a>, S: FutureServiceExt>(server: S) -> (::std::net::SocketAddr, C) {
                 let (server_config, client_config) = tls_context();
                 let addr = t!(server.listen("localhost:0".first_socket_addr(), server_config).wait());
                 let client = t!(C::connect(&addr, client_config).wait());
                 (addr, client)
             }
 
-            fn start_err_server_with_async_client<'a, C: ::future::Connect<'a, Tls>, S: error_service::FutureServiceExt>(server: S) -> (::std::net::SocketAddr, C) {
+            fn start_err_server_with_async_client<'a, C: ::future::Connect<'a>, S: error_service::FutureServiceExt>(server: S) -> (::std::net::SocketAddr, C) {
                 let (server_config, client_config) = tls_context();
                 let addr = t!(server.listen("localhost:0".first_socket_addr(), server_config).wait());
                 let client = t!(C::connect(&addr, client_config).wait());
@@ -969,28 +950,28 @@ mod functional_test {
                 ServerConfig::new_tcp()
             }
 
-            fn get_client_config() -> ClientConfig<Tcp> {
+            fn get_client_config() -> ClientConfig {
                 ClientConfig::new_tcp()
             }
 
-            fn get_sync_client<C: ::sync::Connect<Tcp>>(addr: &::std::net::SocketAddr) -> ::std::io::Result<C> {
+            fn get_sync_client<C: ::sync::Connect>(addr: &::std::net::SocketAddr) -> ::std::io::Result<C> {
                 C::connect(addr, get_client_config())
             }
 
             /// start server and return `SyncClient`
-            fn start_server_with_sync_client<C: ::sync::Connect<Tcp>, S: SyncServiceExt>(server: S) -> (::std::net::SocketAddr, ::std::io::Result<C>) {
+            fn start_server_with_sync_client<C: ::sync::Connect, S: SyncServiceExt>(server: S) -> (::std::net::SocketAddr, ::std::io::Result<C>) {
                 let addr = t!(server.listen("localhost:0".first_socket_addr(), get_server_config()));
                 let client = C::connect(addr, get_client_config());
                 (addr, client)
             }
 
-            fn start_server_with_async_client<'a, C: ::future::Connect<'a, Tcp>, S: FutureServiceExt>(server: S) -> (::std::net::SocketAddr, C) {
+            fn start_server_with_async_client<'a, C: ::future::Connect<'a>, S: FutureServiceExt>(server: S) -> (::std::net::SocketAddr, C) {
                 let addr = t!(server.listen("localhost:0".first_socket_addr(), get_server_config()).wait());
                 let client = t!(C::connect(&addr, get_client_config()).wait());
                 (addr, client)
             }
 
-            fn start_err_server_with_async_client<'a, C: ::future::Connect<'a, Tcp>, S: error_service::FutureServiceExt>(server: S) -> (::std::net::SocketAddr, C) {
+            fn start_err_server_with_async_client<'a, C: ::future::Connect<'a>, S: error_service::FutureServiceExt>(server: S) -> (::std::net::SocketAddr, C) {
                 let addr = t!(server.listen("localhost:0".first_socket_addr(), get_server_config()).wait());
                 let client = t!(C::connect(&addr, get_client_config()).wait());
                 (addr, client)
@@ -1017,7 +998,7 @@ mod functional_test {
         #[test]
         fn simple() {
             let _ = env_logger::init();
-            let (_, client) = start_server_with_sync_client::<SyncClient<_>, Server>(Server);
+            let (_, client) = start_server_with_sync_client::<SyncClient, Server>(Server);
             let client = t!(client);
             assert_eq!(3, client.add(1, 2).unwrap());
             assert_eq!("Hey, Tim.", client.hey("Tim".to_string()).unwrap());
@@ -1026,7 +1007,7 @@ mod functional_test {
         #[test]
         fn other_service() {
             let _ = env_logger::init();
-            let (_, client) = start_server_with_sync_client::<super::other_service::SyncClient<_>,
+            let (_, client) = start_server_with_sync_client::<super::other_service::SyncClient,
                                                               Server>(Server);
             let client = client.expect("Could not connect!");
             match client.foo().err().unwrap() {
@@ -1061,7 +1042,7 @@ mod functional_test {
         #[test]
         fn simple() {
             let _ = env_logger::init();
-            let (_, client) = start_server_with_async_client::<FutureClient<_>, Server>(Server);
+            let (_, client) = start_server_with_async_client::<FutureClient, Server>(Server);
             assert_eq!(3, client.add(1, 2).wait().unwrap());
             assert_eq!("Hey, Tim.", client.hey("Tim".to_string()).wait().unwrap());
         }
@@ -1069,7 +1050,7 @@ mod functional_test {
         #[test]
         fn concurrent() {
             let _ = env_logger::init();
-            let (_, client) = start_server_with_async_client::<FutureClient<_>, Server>(Server);
+            let (_, client) = start_server_with_async_client::<FutureClient, Server>(Server);
             let req1 = client.add(1, 2);
             let req2 = client.add(3, 4);
             let req3 = client.hey("Tim".to_string());
@@ -1082,7 +1063,7 @@ mod functional_test {
         fn other_service() {
             let _ = env_logger::init();
             let (_, client) =
-                start_server_with_async_client::<super::other_service::FutureClient<_>,
+                start_server_with_async_client::<super::other_service::FutureClient,
                                                  Server>(Server);
             match client.foo().wait().err().unwrap() {
                 ::Error::ServerDeserialize(_) => {} // good
@@ -1115,7 +1096,7 @@ mod functional_test {
         use self::error_service::*;
         let _ = env_logger::init();
 
-        let (addr, client) = start_err_server_with_async_client::<FutureClient<_>,
+        let (addr, client) = start_err_server_with_async_client::<FutureClient,
                                                                       ErrorServer>(ErrorServer);
         client.bar()
             .then(move |result| {
@@ -1130,7 +1111,7 @@ mod functional_test {
             .wait()
             .unwrap();
 
-        let client = get_sync_client::<SyncClient<_>>(&addr).unwrap();
+        let client = get_sync_client::<SyncClient>(&addr).unwrap();
         match client.bar().err().unwrap() {
             ::Error::App(e) => {
                 assert_eq!(e.description(), "lol jk");


### PR DESCRIPTION
Like the last PR, for expediency there are some types made public here that really shouldn't be.